### PR TITLE
Update headless-terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "pty.js": "~0.2.1",
         "duplexer": "~0.0.3",
-        "headless-terminal": "0.0.3",
+        "headless-terminal": "0.4.0",
         "through": "~2.2.0",
         "inherits": "~1.0.0"
     },


### PR DESCRIPTION
This PR just update headless-terminal to avoid the node module to define global.document, global.window, ...

Can you please bump version and publish on NPM.

Thank you.